### PR TITLE
Update example for egui 0.19 and wgpu 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,22 +1,23 @@
 [package]
 name = "egui_example"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Nils Hasenbanck <nils@hasenbanck.de>"]
-edition = "2018"
-
-# WGPU requires cargo resolver v2
-resolver = "2"
+edition = "2021"
 
 [dependencies]
-egui-wgpu = "0.18"
+egui-wgpu = "0.19"
 pollster = "0.2"
-egui = "0.18"
-egui-winit = "0.18"
-wgpu = "0.12"
-winit = "0.26"
-egui_demo_lib = "0.18"
+egui = "0.19"
+wgpu = "0.13"
+winit = "0.27"
+egui_demo_lib = "0.19"
 
-[patch.crates-io]
-# egui = { version = "0.5", git = "https://github.com/emilk/egui" }
-# egui_wgpu_backend = { path = "../egui_wgpu_backend" }
-# egui_winit_platform = { path = "../egui_winit_platform" }
+[dependencies.egui-winit]
+version = "0.19"
+# Required for compiling to WASM
+default-features = false
+
+# Required for compiling to WASM
+# Note that you also need RUSTFLAGS=--cfg=web_sys_unstable_apis
+[dependencies.getrandom]
+features = ["js"]

--- a/README.md
+++ b/README.md
@@ -4,9 +4,35 @@ A simple example how to use egui-wgpu-backend with egui-winit-platform to create
 application using egui. This example shows how to integrate egui into
 your own engine.
 
+This version has been updated to use egui 0.19, winit 0.27, and wgpu
+0.13. It should also work on WASM targets once [this
+PR](https://github.com/gfx-rs/wgpu/pull/2954) has been merged into
+wgpu. To make WASM work, all feature flags for the `egui-winit` crate
+have been disabled. None seem to have been required for the example,
+and clipboard isn't supported for web. You may wish to re-enable some
+features for your own projects.
+
+Note that the package structure is a bit different nowadays, so the
+`egui_wgpu_backend` and `egui_winit_platform` packages below are for
+reference only. See this example and the current [egui integration
+docs](https://docs.rs/egui/latest/egui/#integrating-with-egui).
+
  - [egui](https://github.com/emilk/egui)
  - [egui_wgpu_backend](https://github.com/hasenbanck/egui_wgpu_backend)
  - [egui_winit_platform](https://github.com/hasenbanck/egui_winit_platform)
+
+## Compiling to WASM
+
+The easiest way is probably to use
+[cargo-webassembly](https://wasm.js.org/crates/cargo-webassembly/). You'll
+need to add `--cfg=web_sys_unstable_apis` to your `RUSTFLAGS`
+environment variable, otherwise you'll be missing a bunch of
+GPU-related stuff from web_sys.
+
+Note that until [this PR](https://github.com/gfx-rs/wgpu/pull/2954) is
+merged, attempting to compile to WASM will give an error about
+`Depth24unormStencil8` missing from the `GpuTextureFormat` enum,
+because it does not exist on WebGPU.
 
 ## License
 This example is public domain.

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,8 @@ fn main() {
     .unwrap();
 
     let size = window.inner_size();
-    let surface_format = surface.get_preferred_format(&adapter).unwrap();
+    let supported_formats = surface.get_supported_formats(&adapter);
+    let surface_format = supported_formats[0];
     let mut surface_config = wgpu::SurfaceConfiguration {
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
         format: surface_format,
@@ -53,11 +54,9 @@ fn main() {
     };
     surface.configure(&device, &surface_config);
 
-    // We use the egui_winit_platform crate as the platform.
-    let mut state = egui_winit::State::new(4096, &window);
+    let mut state = egui_winit::State::new(&event_loop);
     let context = egui::Context::default();
 
-    // We use the egui_wgpu_backend crate as the render backend.
     let mut egui_rpass = RenderPass::new(&device, surface_format, 1);
 
     // Display the demo application that ships with egui.
@@ -157,3 +156,4 @@ fn main() {
         }
     });
 }
+


### PR DESCRIPTION
Also winit 0.27. Made some changes in Cargo.toml to enable compiling
to WASM.

Updated README.md with the changes and added instructions for
compiling to WASM.